### PR TITLE
Adding graphviz as dependency

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,0 +1,1 @@
+graphviz

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,1 +1,2 @@
 matplotlib==3.*
+graphviz==0.10.*


### PR DESCRIPTION
This PR adds graphviz as a dependency for binder. 
This allows us to draw graphs from python using [graphviz](https://graphviz.readthedocs.io/en/stable/).

This will be useful for visualizing all the tree data structures as well as graph algorithms.

A small disadvantage of using Graphviz is, that students, who use a local installation, need to install it on their system. This should, however, be simple. 


